### PR TITLE
Fixed exception with placeholder interpolation on IE10+

### DIFF
--- a/src/textarea.html
+++ b/src/textarea.html
@@ -5,7 +5,7 @@
             class="form-control {{form.fieldHtmlClass}}"
             id="{{form.key.slice(-1)[0]}}"
             sf-changed="form"
-            placeholder="{{form.placeholder}}"
+            ng-attr-placeholder="{{form.placeholder}}"
             ng-disabled="form.readonly"
             sf-field-model
             schema-validate="form"
@@ -19,7 +19,7 @@
     <textarea class="form-control {{form.fieldHtmlClass}}"
               id="{{form.key.slice(-1)[0]}}"
               sf-changed="form"
-              placeholder="{{form.placeholder}}"
+              ng-attr-placeholder="{{form.placeholder}}"
               ng-disabled="form.readonly"
               sf-field-model
               schema-validate="form"


### PR DESCRIPTION
There is an issue using the placeholder attribute with angular interpolation in IE10+. An invalid operation exception is thrown. Using ng-attr-placeholder works around this problem.

See here 
http://stackoverflow.com/questions/20224698/angularjs-on-ie10-textarea-with-placeholder-cause-invalid-argument
http://stackoverflow.com/questions/20647572/angularjs-v1-2-5-script-error-with-textarea-and-placeholder-attribute-using-ie11/24272011#24272011
