### PR TITLE
Use correct bootstrap styling for inline radio buttons

### DIFF
--- a/src/radio-buttons.html
+++ b/src/radio-buttons.html
@@ -10,12 +10,13 @@
       <input type="radio"
              class="{{form.fieldHtmlClass}}"
              sf-changed="form"
-             style="display: none;"
+             style="position: absolute;clip: rect(0,0,0,0);pointer-events: none;"
              ng-disabled="form.readonly"
              sf-field-model
              schema-validate="form"
              ng-value="item.value"
-             name="{{form.key.join('.')}}">
+             name="{{form.key.join('.')}}"
+             autocomplete="off">
       <span ng-bind-html="item.name"></span>
     </label>
   </div>


### PR DESCRIPTION
"display: none" was used to hide the default radio button in the
inline bootstrap button group. This breaks element.focus(), and may
also hide the element from screen readers. Fortunately bootstrap has
markup to cover this.
