### PR TITLE
fieldset: remove sf-key-controller

### DIFF
--- a/src/bootstrap/fieldset.html
+++ b/src/bootstrap/fieldset.html
@@ -1,4 +1,4 @@
-<fieldset ng-disabled="form.readonly" class="schema-form-fieldset {{::form.htmlClass + ' ' + idClass}}" sf-key-controller sf-parent-key="[{{form.key.join('][')}}]" sf-index="{{$index}}">
+<fieldset ng-disabled="form.readonly" class="schema-form-fieldset {{::form.htmlClass + ' ' + idClass}}">
   <legend ng-class="{'sr-only': !showTitle() }">{{ form.title }}</legend>
   <div class="help-block" ng-show="form.description" ng-bind-html="form.description"></div>
 </fieldset>


### PR DESCRIPTION
`sf-key-controller` is unnecessary for fieldsets, and breaks form.key

####  Fixes Related issues
json-schema-form/angular-schema-form#870

####  Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [x] I have created test cases to ensure quick resolution of the PR is easier
- [x] I am NOT targeting main branch
- [x] I did NOT include the dist folder in my PR

@json-schema-form/angular-schema-form-bootstrap-lead
